### PR TITLE
Small Optimizations

### DIFF
--- a/TL_Installer_Prototype/Program.cs
+++ b/TL_Installer_Prototype/Program.cs
@@ -15,66 +15,74 @@ namespace TL_Installer_Prototype
             ////////////////Declaring Variables//////////////////////////
             
             ///
+            /// Declaring labels
+            ///
+            string label_processComplete = "\n~~~~~~~~~~~~~~~~~~~~> Done!",
+                label_pressAnyKey = "\n~~~~~~~~~~~~~~~~~~~~> Press any key to exit",
+                label_extractPleaseWait = "\n~~~~~~~~~~~~~~~~~~~~> Extracting files - please wait...",
+                label_downloadingFiles = "\n~~~~~~~~~~~~~~~~~~~~> Downloading required files! Please wait.",
+                label_pathNotFound = "\n~~~~~~~~~~~~~~~~~~~~> This is an invalid path (or provided path was not found) - Please try again";
+
+            ///
             /// Declaring Menu Operation Variables
             ///
-            string operation;
-            string operationMenuInstall;
-            string InstallDir;
-            string customInstallDir;
+            string operation,
+                InstallDir,
+                customInstallDir,
+                operationMenuInstall;
 
             ///
             /// Declaring Manual Download File Paths
             ///
-
-            string temmiePath;
-            string temmie_mainPath;
-            string nwJsPath;
-            string fpps4Path;
+            // (nwJsPath) This seems to be declared - but it's never used [Warn list]
+            string fpps4Path,
+                temmiePath,
+                temmie_mainPath;
 
             ///
             /// Declaring Bools
             ///
-            bool instSoF = false;
-            bool checkForTL;
-            bool checkForNw;
-            bool checkForFp;
-            bool checkForTL_Main;
+            bool instSoF = false,
+                checkForTL,
+                checkForNw,
+                checkForFp,
+                checkForTL_Main;
 
             ///
             /// Declaring Enviorment Paths
             ///
-            string TLFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "TL_Installer");
-            string tempDownloadFolder = Path.Combine(TLFolder, "tempDownload");
-            string downloadFolderInstallDir = Path.Combine(Path.Combine(System.Environment.GetEnvironmentVariable("USERPROFILE"), "Downloads"), "Temmie Launcher");
+            string TLFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "TL_Installer"),
+                tempDownloadFolder = Path.Combine(TLFolder, "tempDownload"),
+                downloadFolderInstallDir = Path.Combine(Path.Combine(System.Environment.GetEnvironmentVariable("USERPROFILE"), "Downloads"), "Temmie Launcher");
 
             ///
             ///  Declaring Files with Extensions(zip)
             ///
 
-            string tLFileNameWIthExtension;
-            string fpps4FileNameWIthExtension;
-            string tL_Main_FileNameWIthExtension;
-            string nwjs_FileNameWithExtension = Path.GetFileName(Path.Combine(tempDownloadFolder,"nwjs.zip"));
+            string tLFileNameWIthExtension,
+                fpps4FileNameWIthExtension,
+                tL_Main_FileNameWIthExtension,
+                nwjs_FileNameWithExtension = Path.GetFileName(Path.Combine(tempDownloadFolder,"nwjs.zip"));
 
             ///
             /// Declaring References to classes
             ///
 
-            Extract_Files extractor = new Extract_Files();
-            File_Folder_Mover mover = new File_Folder_Mover();
             Logos logos = new Logos();
+            Extract_Files extractor = new Extract_Files();
+            TL_Downloader tlDownloader = new TL_Downloader();
+            File_Folder_Mover mover = new File_Folder_Mover();
+            NwJs_Downloader nwjsDownloader = new NwJs_Downloader();
+            File_Folder_Deleter deleter = new File_Folder_Deleter();
             fpPS4_Artifact_Json artifactJson = new fpPS4_Artifact_Json();
             fpPS4_Action_Downloader actionDownloader = new fpPS4_Action_Downloader();
-            NwJs_Downloader nwjsDownloader = new NwJs_Downloader();
-            TL_Downloader tlDownloader = new TL_Downloader();
             Write_To_Temmie_Config_Json writeTemmieConfig = new Write_To_Temmie_Config_Json();
-            File_Folder_Deleter deleter = new File_Folder_Deleter();
             
 
                          /////////Declaring fpPS4 Action Variables//////////
-            string GToken = "";
+            string latestArtifactSha, GToken = "";
             Uri endpointArtifactJson = new Uri("https://api.github.com/repos/red-prig/fpPS4/actions/artifacts");
-            string latestArtifactSha = artifactJson.getLatestArtifactSha(GToken,endpointArtifactJson);
+            latestArtifactSha = artifactJson.getLatestArtifactSha(GToken,endpointArtifactJson);
 
             ///
             /// Creating TL_Installer Custom Folder
@@ -99,7 +107,6 @@ namespace TL_Installer_Prototype
                 if (operation == "1")
                 {
                     Console.Clear();
-                    
 
                     while (true)
                     {
@@ -116,7 +123,7 @@ namespace TL_Installer_Prototype
                             {
                                 Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Downloading fpPS4! Please wait.");
                                 actionDownloader.downloadLatestAction(GToken);
-                                Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Done!");
+                                Console.WriteLine(label_processComplete);
                                 checkForFp = true;
                             }
                             else if (File.Exists(Path.Combine(tempDownloadFolder, "fpPS4.zip")))
@@ -128,15 +135,15 @@ namespace TL_Installer_Prototype
                             {
                                 checkForFp = false;
                             }
-                            Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Extracting! Please wait.");
+                            Console.WriteLine(label_extractPleaseWait);
                             extractor.ExtractZipContent(Path.Combine(tempDownloadFolder,"fpPS4.zip"),Path.Combine(tempDownloadFolder,"fpPS4"));
-                            Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Done!");
+                            Console.WriteLine(label_processComplete);
                             checkForFp = true;
                             if (!File.Exists(Path.Combine(tempDownloadFolder, "nwjs.zip")))
                             {
                                 Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Downloading Nw.js! Please wait.");
                                 nwjsDownloader.nwJsDownload();
-                                Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Done!");
+                                Console.WriteLine(label_processComplete);
                                 checkForNw = true;
                             }
                             else if (File.Exists(Path.Combine(tempDownloadFolder, "nwjs.zip")))
@@ -148,15 +155,15 @@ namespace TL_Installer_Prototype
                             {
                                 checkForNw = false;
                             }
-                            Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Extracting! Please wait.");
+                            Console.WriteLine(label_extractPleaseWait);
                             extractor.ExtractZipContent(Path.Combine(tempDownloadFolder, "nwjs.zip"), Path.Combine(tempDownloadFolder, "nwjs"));
-                            Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Done!");
+                            Console.WriteLine(label_processComplete);
                             checkForNw = true;
                             if (!File.Exists(Path.Combine(tempDownloadFolder, "Launcher.zip")))
                             {
                                 Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Downloading Launcher! Please wait.");
                                 tlDownloader.downloadLatestRelease(GToken);
-                                Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Done!");
+                                Console.WriteLine(label_processComplete);
                                 checkForTL = true;
                             }
                             else if (File.Exists(Path.Combine(tempDownloadFolder, "Launcher.zip")))
@@ -168,14 +175,14 @@ namespace TL_Installer_Prototype
                             {
                                 checkForTL = false;
                             }
-                            Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Extracting! Please wait.");
+                            Console.WriteLine(label_extractPleaseWait);
                             extractor.ExtractZipContent(Path.Combine(tempDownloadFolder, "Launcher.zip"), Path.Combine(tempDownloadFolder, "Launcher"));
-                            Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Done!");
+                            Console.WriteLine(label_processComplete);
                             if (!File.Exists(Path.Combine(tempDownloadFolder, "fpPS4-Temmie-s-Launcher-main.zip")))
                             {
                                 Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Downloading fpPS4-Temmie-s-Launcher-main! Please wait.");
                                 tlDownloader.downloadFromMain();
-                                Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Done!");
+                                Console.WriteLine(label_processComplete);
                                 checkForTL_Main = true;
                             }
                             else if (File.Exists(Path.Combine(tempDownloadFolder, "fpPS4-Temmie-s-Launcher-main.zip")))
@@ -187,9 +194,9 @@ namespace TL_Installer_Prototype
                             {
                                 checkForTL_Main = false;
                             }
-                            Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Extracting! Please wait.");
+                            Console.WriteLine(label_extractPleaseWait);
                             extractor.ExtractZipContent(Path.Combine(tempDownloadFolder, "fpPS4-Temmie-s-Launcher-main.zip"), Path.Combine(tempDownloadFolder, "fpPS4-Temmie-s-Launcher-main"));
-                            Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Done!");
+                            Console.WriteLine(label_processComplete);
 
                             logos.Logo4();
                             /// Checks if the needed files exist
@@ -216,7 +223,7 @@ namespace TL_Installer_Prototype
                                     }
                                     else
                                     {
-                                        Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Invalid expression!");
+                                        Console.WriteLine(label_pathNotFound);
                                     }
                                 }
 
@@ -488,7 +495,7 @@ namespace TL_Installer_Prototype
                             {
 
                                 Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Installation finished successfully!");
-                                Console.Write("\n~~~~~~~~~~~~~~~~~~~~> Press any key to Exit");
+                                Console.Write(label_pressAnyKey);
                                 Console.ReadKey();
                                 Console.Clear();
                                 break;
@@ -496,7 +503,7 @@ namespace TL_Installer_Prototype
                             else
                             {
                                 Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Installation Canceled");
-                                Console.Write("\n~~~~~~~~~~~~~~~~~~~~> Press any key to Exit");
+                                Console.Write(label_pressAnyKey);
                                 Console.ReadKey();
                                 Console.Clear();
                                 break;
@@ -620,7 +627,7 @@ namespace TL_Installer_Prototype
                                     }
                                     else
                                     {
-                                        Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Invalid expression!");
+                                        Console.WriteLine(label_pathNotFound);
                                     }
                                 }
 
@@ -646,9 +653,9 @@ namespace TL_Installer_Prototype
                                         }
                                         else
                                         {
-                                            Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Downloading required files! Please wait.");
+                                            Console.WriteLine(label_downloadingFiles);
                                             nwjsDownloader.nwJsDownload();
-                                            Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Done!");
+                                            Console.WriteLine(label_processComplete);
                                         }
                                         
                                         Console.WriteLine($"\n~~~~~~~~~~~~~~~~~~~~> Extracting! {nwjs_FileNameWithExtension}");
@@ -656,20 +663,20 @@ namespace TL_Installer_Prototype
                                         mover.Move_Files_And_Folders(Path.Combine(tempDownloadFolder, "nwjs", "nwjs-v0.70.1-win-x64"), downloadFolderInstallDir);
                                         Directory.Delete(Path.Combine(tempDownloadFolder,"nwjs", "nwjs-v0.70.1-win-x64"));
                                         Directory.Delete(Path.Combine(tempDownloadFolder, "nwjs"));
-                                        Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Done!");
+                                        Console.WriteLine(label_processComplete);
 
                                         ///
                                         /// Extracting Temmie Launcher
                                         ///
                                         Console.WriteLine($"\n~~~~~~~~~~~~~~~~~~~~> Extracting {tLFileNameWIthExtension}");
                                         extractor.ExtractZipContent(temmiePath, downloadFolderInstallDir);
-                                        Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Done!");
+                                        Console.WriteLine(label_processComplete);
 
                                         ///
                                         /// Extracting Temmie Launcher Main
                                         ///
                                         Console.WriteLine($"\n~~~~~~~~~~~~~~~~~~~~> Extracting {tL_Main_FileNameWIthExtension}");
-                                        Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Done!");
+                                        Console.WriteLine(label_processComplete);
                                         extractor.ExtractZipContent(temmie_mainPath, downloadFolderInstallDir);
                                         Console.WriteLine($"\n~~~~~~~~~~~~~~~~~~~~> Moving Files...");
                                         mover.Move_Files_And_Folders(Path.Combine(downloadFolderInstallDir,"fpPS4-Temmie-s-Launcher-main"), downloadFolderInstallDir);
@@ -681,7 +688,7 @@ namespace TL_Installer_Prototype
                                         ///
                                         Console.WriteLine($"\n~~~~~~~~~~~~~~~~~~~~> Extracting {fpps4FileNameWIthExtension}");
                                         extractor.ExtractZipContent(fpps4Path, Path.Combine(downloadFolderInstallDir, "Emu"));
-                                        Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Done!");
+                                        Console.WriteLine(label_processComplete);
 
                                         ///
                                         /// Creating Games and Creating Settings.json
@@ -719,9 +726,9 @@ namespace TL_Installer_Prototype
                                                     }
                                                     else
                                                     {
-                                                        Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Downloading required files! Please wait.");
+                                                        Console.WriteLine(label_downloadingFiles);
                                                         nwjsDownloader.nwJsDownload();
-                                                        Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Done!");
+                                                        Console.WriteLine(label_processComplete);
                                                     }
                                                     ///
                                                     /// Extracting nwjs
@@ -731,14 +738,14 @@ namespace TL_Installer_Prototype
                                                     mover.Move_Files_And_Folders(Path.Combine(tempDownloadFolder, "nwjs", "nwjs-v0.70.1-win-x64"), downloadFolderInstallDir);
                                                     Directory.Delete(Path.Combine(tempDownloadFolder, "nwjs", "nwjs-v0.70.1-win-x64"));
                                                     Directory.Delete(Path.Combine(tempDownloadFolder, "nwjs"));
-                                                    Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Done!");
+                                                    Console.WriteLine(label_processComplete);
 
                                                     ///
                                                     /// Extracting Temmie Launcher
                                                     ///
                                                     Console.WriteLine($"\n~~~~~~~~~~~~~~~~~~~~> Extracting {tLFileNameWIthExtension}");
                                                     extractor.ExtractZipContent(temmiePath, downloadFolderInstallDir);
-                                                    Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Done!");
+                                                    Console.WriteLine(label_processComplete);
 
                                                     ///
                                                     /// Extracting Temmie Launcher Main
@@ -746,7 +753,7 @@ namespace TL_Installer_Prototype
 
                                                     Console.WriteLine($"\n~~~~~~~~~~~~~~~~~~~~> Extracting {tL_Main_FileNameWIthExtension}");
                                                     extractor.ExtractZipContent(temmie_mainPath, downloadFolderInstallDir);
-                                                    Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Done!");
+                                                    Console.WriteLine(label_processComplete);
                                                     Console.WriteLine($"\n~~~~~~~~~~~~~~~~~~~~> Moving Files...");
                                                     mover.Move_Files_And_Folders(Path.Combine(downloadFolderInstallDir, "fpPS4-Temmie-s-Launcher-main"), downloadFolderInstallDir);
                                                     Directory.Delete(Path.Combine(downloadFolderInstallDir, "fpPS4-Temmie-s-Launcher-main"));
@@ -756,7 +763,7 @@ namespace TL_Installer_Prototype
                                                     ///
                                                     Console.WriteLine($"\n~~~~~~~~~~~~~~~~~~~~> Extracting {fpps4FileNameWIthExtension}");
                                                     extractor.ExtractZipContent(fpps4Path, Path.Combine(downloadFolderInstallDir, "Emu"));
-                                                    Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Done!");
+                                                    Console.WriteLine(label_processComplete);
 
                                                     ///
                                                     /// Creating Games and Creating Settings.json
@@ -794,9 +801,9 @@ namespace TL_Installer_Prototype
                                             }
                                             else
                                             {
-                                                Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Downloading required files! Please wait.");
+                                                Console.WriteLine(label_downloadingFiles);
                                                 nwjsDownloader.nwJsDownload();
-                                                Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Done!");
+                                                Console.WriteLine(label_processComplete);
                                             }
                                             ///
                                             /// Extracing nwjs
@@ -806,21 +813,21 @@ namespace TL_Installer_Prototype
                                             mover.Move_Files_And_Folders(Path.Combine(tempDownloadFolder, "nwjs", "nwjs-v0.70.1-win-x64"), downloadFolderInstallDir);
                                             Directory.Delete(Path.Combine(tempDownloadFolder, "nwjs", "nwjs-v0.70.1-win-x64"));
                                             Directory.Delete(Path.Combine(tempDownloadFolder, "nwjs"));
-                                            Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Done!");
+                                            Console.WriteLine(label_processComplete);
 
                                             ///
                                             /// Extracting Temmie Launcher
                                             ///
                                             Console.WriteLine($"\n~~~~~~~~~~~~~~~~~~~~> Extracting {tLFileNameWIthExtension}");
                                             extractor.ExtractZipContent(temmiePath, downloadFolderInstallDir);
-                                            Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Done!");
+                                            Console.WriteLine(label_processComplete);
 
                                             ///
                                             /// Extracting Temmie Launcher Main
                                             ///
                                             Console.WriteLine($"\n~~~~~~~~~~~~~~~~~~~~> Extracting {tL_Main_FileNameWIthExtension}");
                                             extractor.ExtractZipContent(temmie_mainPath, downloadFolderInstallDir);
-                                            Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Done!");
+                                            Console.WriteLine(label_processComplete);
                                             Console.WriteLine($"\n~~~~~~~~~~~~~~~~~~~~> Moving Files...");
                                             mover.Move_Files_And_Folders(Path.Combine(downloadFolderInstallDir, "fpPS4-Temmie-s-Launcher-main"), downloadFolderInstallDir);
                                             Directory.Delete(Path.Combine(downloadFolderInstallDir, "fpPS4-Temmie-s-Launcher-main"));
@@ -830,7 +837,7 @@ namespace TL_Installer_Prototype
                                             ///
                                             Console.WriteLine($"\n~~~~~~~~~~~~~~~~~~~~> Extracting {fpps4FileNameWIthExtension}");
                                             extractor.ExtractZipContent(fpps4Path, Path.Combine(downloadFolderInstallDir, "Emu"));
-                                            Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Done!");
+                                            Console.WriteLine(label_processComplete);
 
                                             ///
                                             /// Creating Games and Creating Settings.json
@@ -868,9 +875,9 @@ namespace TL_Installer_Prototype
                                         }
                                         else
                                         {
-                                            Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Downloading required files! Please wait.");
+                                            Console.WriteLine(label_downloadingFiles);
                                             nwjsDownloader.nwJsDownload();
-                                            Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Done!");
+                                            Console.WriteLine(label_processComplete);
                                         }
 
                                         ///
@@ -881,14 +888,14 @@ namespace TL_Installer_Prototype
                                         mover.Move_Files_And_Folders(Path.Combine(tempDownloadFolder, "nwjs", "nwjs-v0.70.1-win-x64"), customInstallDir);
                                         Directory.Delete(Path.Combine(tempDownloadFolder, "nwjs", "nwjs-v0.70.1-win-x64"));
                                         Directory.Delete(Path.Combine(tempDownloadFolder, "nwjs"));
-                                        Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Done!");
+                                        Console.WriteLine(label_processComplete);
 
                                         ///
                                         /// Extracting Temmie Launcher
                                         ///
                                         Console.WriteLine($"\n~~~~~~~~~~~~~~~~~~~~> Extracting {tLFileNameWIthExtension}");
                                         extractor.ExtractZipContent(temmiePath, customInstallDir);
-                                        Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Done!");
+                                        Console.WriteLine(label_processComplete);
 
                                         ///
                                         /// Extracting Temmie Launcher Main
@@ -896,7 +903,7 @@ namespace TL_Installer_Prototype
 
                                         Console.WriteLine($"\n~~~~~~~~~~~~~~~~~~~~> Extracting {tL_Main_FileNameWIthExtension}");
                                         extractor.ExtractZipContent(temmie_mainPath, customInstallDir);
-                                        Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Done!");
+                                        Console.WriteLine(label_processComplete);
                                         Console.WriteLine($"\n~~~~~~~~~~~~~~~~~~~~> Moving Files...");
                                         mover.Move_Files_And_Folders(Path.Combine(customInstallDir, "fpPS4-Temmie-s-Launcher-main"), customInstallDir);
                                         Directory.Delete(Path.Combine(customInstallDir, "fpPS4-Temmie-s-Launcher-main"));
@@ -906,7 +913,7 @@ namespace TL_Installer_Prototype
                                         ///
                                         Console.WriteLine($"\n~~~~~~~~~~~~~~~~~~~~> Extracting {fpps4FileNameWIthExtension}");
                                         extractor.ExtractZipContent(fpps4Path, Path.Combine(customInstallDir, "Emu"));
-                                        Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Done!");
+                                        Console.WriteLine(label_processComplete);
 
                                         ///
                                         /// Creating Games and Creating Settings.json
@@ -944,9 +951,9 @@ namespace TL_Installer_Prototype
                                                     }
                                                     else
                                                     {
-                                                        Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Downloading required files! Please wait.");
+                                                        Console.WriteLine(label_downloadingFiles);
                                                         nwjsDownloader.nwJsDownload();
-                                                        Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Done!");
+                                                        Console.WriteLine(label_processComplete);
                                                     }
 
                                                     ///
@@ -957,21 +964,21 @@ namespace TL_Installer_Prototype
                                                     mover.Move_Files_And_Folders(Path.Combine(tempDownloadFolder, "nwjs", "nwjs-v0.70.1-win-x64"), customInstallDir);
                                                     Directory.Delete(Path.Combine(tempDownloadFolder, "nwjs", "nwjs-v0.70.1-win-x64"));
                                                     Directory.Delete(Path.Combine(tempDownloadFolder, "nwjs"));
-                                                    Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Done!");
+                                                    Console.WriteLine(label_processComplete);
 
                                                     ///
                                                     /// Extracting Temmie Launcher
                                                     ///
                                                     Console.WriteLine($"\n~~~~~~~~~~~~~~~~~~~~> Extracting {tLFileNameWIthExtension}");
                                                     extractor.ExtractZipContent(temmiePath, customInstallDir);
-                                                    Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Done!");
+                                                    Console.WriteLine(label_processComplete);
 
                                                     ///
                                                     /// Extracting Temmie Launcher Main
                                                     ///
                                                     Console.WriteLine($"\n~~~~~~~~~~~~~~~~~~~~> Extracting {tL_Main_FileNameWIthExtension}");
                                                     extractor.ExtractZipContent(temmie_mainPath, customInstallDir);
-                                                    Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Done!");
+                                                    Console.WriteLine(label_processComplete);
                                                     Console.WriteLine($"\n~~~~~~~~~~~~~~~~~~~~> Moving Files...");
                                                     mover.Move_Files_And_Folders(Path.Combine(customInstallDir, "fpPS4-Temmie-s-Launcher-main"), customInstallDir);
                                                     Directory.Delete(Path.Combine(customInstallDir, "fpPS4-Temmie-s-Launcher-main"));
@@ -981,7 +988,7 @@ namespace TL_Installer_Prototype
                                                     ///
                                                     Console.WriteLine($"\n~~~~~~~~~~~~~~~~~~~~> Extracting {fpps4FileNameWIthExtension}");
                                                     extractor.ExtractZipContent(fpps4Path, Path.Combine(customInstallDir, "Emu"));
-                                                    Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Done!");
+                                                    Console.WriteLine(label_processComplete);
 
                                                     ///
                                                     /// Creating Games Folder and Creating Settings.json
@@ -1018,9 +1025,9 @@ namespace TL_Installer_Prototype
                                             }
                                             else
                                             {
-                                                Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Downloading required files! Please wait.");
+                                                Console.WriteLine(label_downloadingFiles);
                                                 nwjsDownloader.nwJsDownload();
-                                                Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Done!");
+                                                Console.WriteLine(label_processComplete);
                                             }
 
                                             ///
@@ -1031,14 +1038,14 @@ namespace TL_Installer_Prototype
                                             mover.Move_Files_And_Folders(Path.Combine(tempDownloadFolder, "nwjs", "nwjs-v0.70.1-win-x64"), customInstallDir);
                                             Directory.Delete(Path.Combine(tempDownloadFolder, "nwjs", "nwjs-v0.70.1-win-x64"));
                                             Directory.Delete(Path.Combine(tempDownloadFolder, "nwjs"));
-                                            Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Done!");
+                                            Console.WriteLine(label_processComplete);
 
                                             ///
                                             /// Extracting Temmie Launcher
                                             ///
                                             Console.WriteLine($"\n~~~~~~~~~~~~~~~~~~~~> Extracting {tLFileNameWIthExtension}");
                                             extractor.ExtractZipContent(temmiePath, customInstallDir);
-                                            Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Done!");
+                                            Console.WriteLine(label_processComplete);
 
                                             ///
                                             /// Extracting Temmie Launcher Main
@@ -1046,7 +1053,7 @@ namespace TL_Installer_Prototype
 
                                             Console.WriteLine($"\n~~~~~~~~~~~~~~~~~~~~> Extracting {tL_Main_FileNameWIthExtension}");
                                             extractor.ExtractZipContent(temmie_mainPath, customInstallDir);
-                                            Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Done!");
+                                            Console.WriteLine(label_processComplete);
                                             Console.WriteLine($"\n~~~~~~~~~~~~~~~~~~~~> Moving Files...");
                                             mover.Move_Files_And_Folders(Path.Combine(customInstallDir, "fpPS4-Temmie-s-Launcher-main"), customInstallDir);
                                             Directory.Delete(Path.Combine(customInstallDir, "fpPS4-Temmie-s-Launcher-main"));
@@ -1056,7 +1063,7 @@ namespace TL_Installer_Prototype
                                             ///
                                             Console.WriteLine($"\n~~~~~~~~~~~~~~~~~~~~> Extracting {fpps4FileNameWIthExtension}");
                                             extractor.ExtractZipContent(fpps4Path, Path.Combine(customInstallDir, "Emu"));
-                                            Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Done!");
+                                            Console.WriteLine(label_processComplete);
 
                                             ///
                                             /// Creating Games Folder and Creating Settings.json
@@ -1081,7 +1088,7 @@ namespace TL_Installer_Prototype
                             if (instSoF == true)
                             {
                                 Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Installation finished successfully!");
-                                Console.Write("\n~~~~~~~~~~~~~~~~~~~~> Press any key to Exit");
+                                Console.Write(label_pressAnyKey);
                                 Console.ReadKey();
                                 Console.Clear();
                                 break;
@@ -1089,7 +1096,7 @@ namespace TL_Installer_Prototype
                             else
                             {
                                 Console.WriteLine("\n~~~~~~~~~~~~~~~~~~~~> Installation Canceled!");
-                                Console.Write("\n~~~~~~~~~~~~~~~~~~~~> Press any key to Exit");
+                                Console.Write(label_pressAnyKey);
                                 Console.ReadKey();
                                 Console.Clear();
                                 break;

--- a/TL_Installer_Prototype/Program.cs
+++ b/TL_Installer_Prototype/Program.cs
@@ -15,7 +15,7 @@ namespace TL_Installer_Prototype
             ////////////////Declaring Variables//////////////////////////
             
             ///
-            /// Declaring labels
+            /// Declaring common string variables
             ///
             string label_processComplete = "\n~~~~~~~~~~~~~~~~~~~~> Done!",
                 label_pressAnyKey = "\n~~~~~~~~~~~~~~~~~~~~> Press any key to exit",

--- a/TL_Installer_Prototype/Program.cs
+++ b/TL_Installer_Prototype/Program.cs
@@ -17,52 +17,51 @@ namespace TL_Installer_Prototype
             ///
             /// Declaring common string variables
             ///
-            string label_processComplete = "\n~~~~~~~~~~~~~~~~~~~~> Done!",
-                label_pressAnyKey = "\n~~~~~~~~~~~~~~~~~~~~> Press any key to exit",
-                label_extractPleaseWait = "\n~~~~~~~~~~~~~~~~~~~~> Extracting files - please wait...",
-                label_downloadingFiles = "\n~~~~~~~~~~~~~~~~~~~~> Downloading required files! Please wait.",
-                label_pathNotFound = "\n~~~~~~~~~~~~~~~~~~~~> This is an invalid path (or provided path was not found) - Please try again";
+            string label_processComplete = "\n~~~~~~~~~~~~~~~~~~~~> Done!";
+            string label_pressAnyKey = "\n~~~~~~~~~~~~~~~~~~~~> Press any key to exit";
+            string label_extractPleaseWait = "\n~~~~~~~~~~~~~~~~~~~~> Extracting files - please wait...";
+            string label_downloadingFiles = "\n~~~~~~~~~~~~~~~~~~~~> Downloading required files! Please wait.";
+            string label_pathNotFound = "\n~~~~~~~~~~~~~~~~~~~~> This is an invalid path (or provided path was not found) - Please try again";
 
             ///
             /// Declaring Menu Operation Variables
             ///
-            string operation,
-                InstallDir,
-                customInstallDir,
-                operationMenuInstall;
+            string operation;
+            string InstallDir;
+            string customInstallDir;
+            string operationMenuInstall;
 
             ///
             /// Declaring Manual Download File Paths
             ///
             // (nwJsPath) This seems to be declared - but it's never used [Warn list]
-            string fpps4Path,
-                temmiePath,
-                temmie_mainPath;
+            string fpps4Path;
+            string temmiePath;
+            string temmie_mainPath;
 
             ///
             /// Declaring Bools
             ///
-            bool instSoF = false,
-                checkForTL,
-                checkForNw,
-                checkForFp,
-                checkForTL_Main;
+            bool instSoF = false;
+            bool checkForTL;
+            bool checkForNw;
+            bool checkForFp;
+            bool checkForTL_Main;
 
             ///
             /// Declaring Enviorment Paths
             ///
-            string TLFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "TL_Installer"),
-                tempDownloadFolder = Path.Combine(TLFolder, "tempDownload"),
-                downloadFolderInstallDir = Path.Combine(Path.Combine(System.Environment.GetEnvironmentVariable("USERPROFILE"), "Downloads"), "Temmie Launcher");
+            string TLFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "TL_Installer");
+            string tempDownloadFolder = Path.Combine(TLFolder, "tempDownload");
+            string downloadFolderInstallDir = Path.Combine(Path.Combine(System.Environment.GetEnvironmentVariable("USERPROFILE"), "Downloads"), "Temmie Launcher");
 
             ///
             ///  Declaring Files with Extensions(zip)
             ///
-
-            string tLFileNameWIthExtension,
-                fpps4FileNameWIthExtension,
-                tL_Main_FileNameWIthExtension,
-                nwjs_FileNameWithExtension = Path.GetFileName(Path.Combine(tempDownloadFolder,"nwjs.zip"));
+            string tLFileNameWIthExtension;
+            string fpps4FileNameWIthExtension;
+            string tL_Main_FileNameWIthExtension;
+            string nwjs_FileNameWithExtension = Path.GetFileName(Path.Combine(tempDownloadFolder,"nwjs.zip"));
 
             ///
             /// Declaring References to classes
@@ -80,14 +79,13 @@ namespace TL_Installer_Prototype
             
 
                          /////////Declaring fpPS4 Action Variables//////////
-            string latestArtifactSha, GToken = "";
+            string GToken = "";
+            string latestArtifactSha = artifactJson.getLatestArtifactSha(GToken,endpointArtifactJson);
             Uri endpointArtifactJson = new Uri("https://api.github.com/repos/red-prig/fpPS4/actions/artifacts");
-            latestArtifactSha = artifactJson.getLatestArtifactSha(GToken,endpointArtifactJson);
 
             ///
             /// Creating TL_Installer Custom Folder
             ///
-
             if (!Directory.Exists(TLFolder))
             {
                 DirectoryInfo di = Directory.CreateDirectory(TLFolder);


### PR DESCRIPTION
This PR contains some small optimizations on `Program.cs`:

- Remove unused variable (nwJsPath - see line 37)
- Reduce file size by using variables for common strings (Like "Press any key to exit" or "Extracting files"...)
- _(Reverted on c31d970)_ Declare multiples strings and bools variables using one calling and comma (see line 20, 29, 38 and 45 as example)